### PR TITLE
avoid joysticks to "stick" to the last position

### DIFF
--- a/lib/src/joystick.dart
+++ b/lib/src/joystick.dart
@@ -106,6 +106,10 @@ class _JoystickState extends State<Joystick> {
     setState(() {
       _stickOffset = Offset.zero;
     });
+    
+    // update the widget once more so that we send out a 0, instead of having
+    // the joystick "hang" at the last known position
+    widget.listener(StickDragDetails(_stickOffset.dx, _stickOffset.dy));
 
     _callbackTimer?.cancel();
     _startDragStickPosition = Offset.zero;


### PR DESCRIPTION
users normally expect the joystick to send out a zero when letting go of the controls