### PR TITLE
Allow fine grained control over the underlying Widgets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,24 @@
+## 0.0.5
+
+- Added animation logic to the `Joystick` to animate the `JoystickStick` on load which can be toggled using `includeInitialAnimation` parameter.
+- Added: Support for customizing `arrowsColor`, `boxShadows` and `withBorderCircle` parameter in `JoystickBase`.
+- Added: Support for customizing `color` and `shadowColor` parameters in `JoystickStick`.
+- Added new `JoystickArrows` widget and removed the current arrow rendering logic from `JoystickBase` widget. The arrows in `JoystickArrows` animate and the animation can be toggled using `enableArrowAnimation` in `JoystickBase` widget.
+- Added new `ColorUtils` class which exposes static `darken` and `lighten` methods.
+
 ## 0.0.4
 
-* Added: Support for customizing `drawArrows`, `size`, and `color` parameters in `JoystickBase`.
-* Added: Support for customizing `size` parameter in `JoystickStick`.
+- Added: Support for customizing `drawArrows`, `size`, and `color` parameters in `JoystickBase`.
+- Added: Support for customizing `size` parameter in `JoystickStick`.
 
 ## 0.0.3
 
-* Added a send of zero offset to the joystick listener when the stick is released
+- Added a send of zero offset to the joystick listener when the stick is released
 
 ## 0.0.2
 
-* Added callbacks that are called when the stick starts and ends movement
+- Added callbacks that are called when the stick starts and ends movement
 
 ## 0.0.1
 
-* Added Joystick widget. Added JoystickArea widget.
+- Added Joystick widget. Added JoystickArea widget.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,8 +81,9 @@ class _JoystickExampleState extends State<JoystickExample> {
   double _x = 100;
   double _y = 100;
   JoystickMode _joystickMode = JoystickMode.all;
-  bool includeInitialAnimation = true;
   bool drawArrows = true;
+  bool includeInitialAnimation = true;
+  bool enableArrowAnimation = false;
   bool isBlueJoystick = false;
   bool withBorderCircle = false;
   Key key = UniqueKey();
@@ -93,6 +94,12 @@ class _JoystickExampleState extends State<JoystickExample> {
     super.didChangeDependencies();
   }
 
+  void _updateDrawArrows() {
+    setState(() {
+      drawArrows = !drawArrows;
+    });
+  }
+
   void _updateInitialAnimation() {
     setState(() {
       includeInitialAnimation = !includeInitialAnimation;
@@ -100,21 +107,21 @@ class _JoystickExampleState extends State<JoystickExample> {
     });
   }
 
-  void _updateDrawArrows() {
+  void _updateBlueJoystick() {
     setState(() {
-      drawArrows = !drawArrows;
+      isBlueJoystick = !isBlueJoystick;
+    });
+  }
+
+  void _updateArrowAnimation() {
+    setState(() {
+      enableArrowAnimation = !enableArrowAnimation;
     });
   }
 
   void _updateBorderCircle() {
     setState(() {
       withBorderCircle = !withBorderCircle;
-    });
-  }
-
-  void _updateBlueJoystick() {
-    setState(() {
-      isBlueJoystick = !isBlueJoystick;
     });
   }
 
@@ -163,6 +170,7 @@ class _JoystickExampleState extends State<JoystickExample> {
                             ? Colors.lightBlue.shade600
                             : Colors.black,
                         drawArrows: drawArrows,
+                        enableArrowAnimation: enableArrowAnimation,
                         mode: _joystickMode,
                         withBorderCircle: withBorderCircle,
                       ),
@@ -198,6 +206,10 @@ class _JoystickExampleState extends State<JoystickExample> {
                           value:
                               'Joystick Color: ${isBlueJoystick ? 'Blue' : 'Black'}',
                           clickHandler: _updateBlueJoystick,
+                        ),
+                        buildButton(
+                          value: 'Animated Arrows? : $enableArrowAnimation',
+                          clickHandler: _updateArrowAnimation,
                         ),
                       ],
                     )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,11 +81,41 @@ class _JoystickExampleState extends State<JoystickExample> {
   double _x = 100;
   double _y = 100;
   JoystickMode _joystickMode = JoystickMode.all;
+  bool includeInitialAnimation = true;
+  bool drawArrows = true;
+  bool isBlueJoystick = false;
+  bool withBorderCircle = false;
+  Key key = UniqueKey();
 
   @override
   void didChangeDependencies() {
     _x = MediaQuery.of(context).size.width / 2 - ballSize / 2;
     super.didChangeDependencies();
+  }
+
+  void _updateInitialAnimation() {
+    setState(() {
+      includeInitialAnimation = !includeInitialAnimation;
+      key = UniqueKey();
+    });
+  }
+
+  void _updateDrawArrows() {
+    setState(() {
+      drawArrows = !drawArrows;
+    });
+  }
+
+  void _updateBorderCircle() {
+    setState(() {
+      withBorderCircle = !withBorderCircle;
+    });
+  }
+
+  void _updateBlueJoystick() {
+    setState(() {
+      isBlueJoystick = !isBlueJoystick;
+    });
   }
 
   @override
@@ -109,22 +139,85 @@ class _JoystickExampleState extends State<JoystickExample> {
         child: Stack(
           children: [
             Container(
-              color: Colors.green,
+              color: Colors.grey.shade100,
             ),
             Ball(_x, _y),
             Align(
-              alignment: const Alignment(0, 0.8),
-              child: Joystick(
-                mode: _joystickMode,
-                listener: (details) {
-                  setState(() {
-                    _x = _x + step * details.x;
-                    _y = _y + step * details.y;
-                  });
-                },
+              alignment: const Alignment(0, 0.9),
+              child: Container(
+                width: MediaQuery.of(context).size.width,
+                height: 300.0,
+                color: Colors.blueGrey.shade700,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Joystick(
+                      includeInitialAnimation: includeInitialAnimation,
+                      key: key,
+                      base: JoystickBase(
+                        arrowsColor: isBlueJoystick
+                            ? Colors.grey.shade200
+                            : Colors.grey.shade400,
+                        color: isBlueJoystick
+                            ? Colors.lightBlue.shade600
+                            : Colors.black,
+                        drawArrows: drawArrows,
+                        mode: _joystickMode,
+                        withBorderCircle: withBorderCircle,
+                      ),
+                      stick: JoystickStick(
+                        color: isBlueJoystick
+                            ? Colors.blue.shade600
+                            : Colors.blue.shade700,
+                      ),
+                      mode: _joystickMode,
+                      listener: (details) {
+                        setState(() {
+                          _x = _x + step * details.x;
+                          _y = _y + step * details.y;
+                        });
+                      },
+                    ),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        buildButton(
+                          value: 'Initial Animation: $includeInitialAnimation',
+                          clickHandler: _updateInitialAnimation,
+                        ),
+                        buildButton(
+                          value: 'Draw Arrows: $drawArrows',
+                          clickHandler: _updateDrawArrows,
+                        ),
+                        buildButton(
+                          value: 'Draw Border Circle: $withBorderCircle',
+                          clickHandler: _updateBorderCircle,
+                        ),
+                        buildButton(
+                          value:
+                              'Joystick Color: ${isBlueJoystick ? 'Blue' : 'Black'}',
+                          clickHandler: _updateBlueJoystick,
+                        ),
+                      ],
+                    )
+                  ],
+                ),
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget buildButton({required String value, required clickHandler}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10.0),
+      child: ElevatedButton(
+        onPressed: clickHandler,
+        child: Text(
+          value,
         ),
       ),
     );
@@ -236,7 +329,9 @@ class _SquareJoystickExampleState extends State<SquareJoystickExample> {
               alignment: const Alignment(0, 0.8),
               child: Joystick(
                 mode: _joystickMode,
-                base: JoystickSquareBase(mode: _joystickMode),
+                base: JoystickSquareBase(
+                  mode: _joystickMode,
+                ),
                 stickOffsetCalculator: const RectangleStickOffsetCalculator(),
                 listener: (details) {
                   setState(() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -74,6 +74,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -86,34 +110,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -131,18 +155,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -163,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -175,13 +199,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.1.3 <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -90,7 +90,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -192,7 +191,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
-
   vector_math:
     dependency: transitive
     description:
@@ -212,4 +210,3 @@ packages:
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"
-

--- a/lib/flutter_joystick.dart
+++ b/lib/flutter_joystick.dart
@@ -6,3 +6,4 @@ export 'src/joystick_base.dart';
 export 'src/joystick_controller.dart';
 export 'src/joystick_stick.dart';
 export 'src/joystick_stick_offset_calculator.dart';
+export 'src/utils.dart';

--- a/lib/src/joystick.dart
+++ b/lib/src/joystick.dart
@@ -58,6 +58,7 @@ class _JoystickState extends State<Joystick> {
 
   Offset _stickOffset = Offset.zero;
   Timer? _callbackTimer;
+  final double _moveValue = 24.0;
   Offset _startDragStickPosition = Offset.zero;
 
   @override
@@ -68,7 +69,10 @@ class _JoystickState extends State<Joystick> {
     widget.controller?.onStickDragUpdate =
         (globalPosition) => _stickDragUpdate(globalPosition);
     widget.controller?.onStickDragEnd = () => _stickDragEnd();
-    Future.delayed(const Duration(milliseconds: 300), () => _animateJoystick());
+    Future.delayed(
+      const Duration(milliseconds: 300),
+      () => _animateJoystick(),
+    );
   }
 
   @override
@@ -91,44 +95,54 @@ class _JoystickState extends State<Joystick> {
   }
 
   void _animateJoystick() async {
-    Duration duration = const Duration(milliseconds: 120);
+    Duration duration = const Duration(milliseconds: 200);
     if (widget.mode == JoystickMode.vertical) {
       await _moveInYAxis(duration);
     } else if (widget.mode == JoystickMode.horizontal) {
       await _moveInXAxis(duration);
     } else {
-      duration = const Duration(milliseconds: 60);
+      duration = const Duration(milliseconds: 160);
       await _moveInXAxis(duration);
       await _moveInYAxis(duration);
     }
   }
 
   _moveInXAxis(Duration duration) async {
-    Offset startRight = const Offset(-90, 0);
-    Offset moveRight = const Offset(-40, 0);
-    Offset center = const Offset(0, 0);
-    Offset moveLeft = const Offset(40, 0);
-    Offset endLeft = const Offset(90, 0);
-    _stickDragUpdate(startRight);
-    await Future.delayed(duration, () => _stickDragUpdate(moveRight));
-    await Future.delayed(duration, () => _stickDragUpdate(center));
-    await Future.delayed(duration, () => _stickDragUpdate(moveLeft));
-    await Future.delayed(duration, () => _stickDragUpdate(endLeft));
-    await Future.delayed(duration, () => _stickDragUpdate(center));
+    Offset moveLeft = Offset(-_moveValue, 0);
+    Offset moveRight = Offset(_moveValue, 0);
+    Offset center = _startDragStickPosition;
+
+    await Future.delayed(
+      duration,
+      () => _stickDragUpdate(moveLeft),
+    );
+    await Future.delayed(
+      duration,
+      () => _stickDragUpdate(moveRight),
+    );
+    await Future.delayed(
+      duration,
+      () => _stickDragUpdate(center),
+    );
   }
 
   _moveInYAxis(Duration duration) async {
-    Offset startTop = const Offset(0, -90);
-    Offset moveTop = const Offset(0, -40);
-    Offset center = const Offset(0, 0);
-    Offset moveBottom = const Offset(0, 40);
-    Offset endBottom = const Offset(0, 90);
-    await Future.delayed(duration, () => _stickDragUpdate(startTop));
-    await Future.delayed(duration, () => _stickDragUpdate(moveTop));
-    await Future.delayed(duration, () => _stickDragUpdate(center));
-    await Future.delayed(duration, () => _stickDragUpdate(moveBottom));
-    await Future.delayed(duration, () => _stickDragUpdate(endBottom));
-    await Future.delayed(duration, () => _stickDragUpdate(center));
+    Offset moveTop = Offset(0, -_moveValue);
+    Offset moveBottom = Offset(0, _moveValue);
+    Offset center = _startDragStickPosition;
+
+    await Future.delayed(
+      duration,
+      () => _stickDragUpdate(moveTop),
+    );
+    await Future.delayed(
+      duration,
+      () => _stickDragUpdate(moveBottom),
+    );
+    await Future.delayed(
+      duration,
+      () => _stickDragUpdate(center),
+    );
   }
 
   void _stickDragStart(Offset globalPosition) {

--- a/lib/src/joystick.dart
+++ b/lib/src/joystick.dart
@@ -36,6 +36,8 @@ class Joystick extends StatefulWidget {
   /// Callback, which is called when the stick released.
   final Function? onStickDragEnd;
 
+  final bool includeInitialAnimation;
+
   const Joystick({
     Key? key,
     required this.listener,
@@ -47,6 +49,7 @@ class Joystick extends StatefulWidget {
     this.controller,
     this.onStickDragStart,
     this.onStickDragEnd,
+    this.includeInitialAnimation = true,
   }) : super(key: key);
 
   @override
@@ -69,10 +72,12 @@ class _JoystickState extends State<Joystick> {
     widget.controller?.onStickDragUpdate =
         (globalPosition) => _stickDragUpdate(globalPosition);
     widget.controller?.onStickDragEnd = () => _stickDragEnd();
-    Future.delayed(
-      const Duration(milliseconds: 300),
-      () => _animateJoystick(),
-    );
+    if (widget.includeInitialAnimation) {
+      Future.delayed(
+        const Duration(milliseconds: 300),
+        () => _animateJoystick(),
+      );
+    }
   }
 
   @override

--- a/lib/src/joystick.dart
+++ b/lib/src/joystick.dart
@@ -68,6 +68,7 @@ class _JoystickState extends State<Joystick> {
     widget.controller?.onStickDragUpdate =
         (globalPosition) => _stickDragUpdate(globalPosition);
     widget.controller?.onStickDragEnd = () => _stickDragEnd();
+    Future.delayed(const Duration(milliseconds: 300), () => _animateJoystick());
   }
 
   @override
@@ -87,6 +88,47 @@ class _JoystickState extends State<Joystick> {
         ),
       ],
     );
+  }
+
+  void _animateJoystick() async {
+    Duration duration = const Duration(milliseconds: 120);
+    if (widget.mode == JoystickMode.vertical) {
+      await _moveInYAxis(duration);
+    } else if (widget.mode == JoystickMode.horizontal) {
+      await _moveInXAxis(duration);
+    } else {
+      duration = const Duration(milliseconds: 60);
+      await _moveInXAxis(duration);
+      await _moveInYAxis(duration);
+    }
+  }
+
+  _moveInXAxis(Duration duration) async {
+    Offset startRight = const Offset(-90, 0);
+    Offset moveRight = const Offset(-40, 0);
+    Offset center = const Offset(0, 0);
+    Offset moveLeft = const Offset(40, 0);
+    Offset endLeft = const Offset(90, 0);
+    _stickDragUpdate(startRight);
+    await Future.delayed(duration, () => _stickDragUpdate(moveRight));
+    await Future.delayed(duration, () => _stickDragUpdate(center));
+    await Future.delayed(duration, () => _stickDragUpdate(moveLeft));
+    await Future.delayed(duration, () => _stickDragUpdate(endLeft));
+    await Future.delayed(duration, () => _stickDragUpdate(center));
+  }
+
+  _moveInYAxis(Duration duration) async {
+    Offset startTop = const Offset(0, -90);
+    Offset moveTop = const Offset(0, -40);
+    Offset center = const Offset(0, 0);
+    Offset moveBottom = const Offset(0, 40);
+    Offset endBottom = const Offset(0, 90);
+    await Future.delayed(duration, () => _stickDragUpdate(startTop));
+    await Future.delayed(duration, () => _stickDragUpdate(moveTop));
+    await Future.delayed(duration, () => _stickDragUpdate(center));
+    await Future.delayed(duration, () => _stickDragUpdate(moveBottom));
+    await Future.delayed(duration, () => _stickDragUpdate(endBottom));
+    await Future.delayed(duration, () => _stickDragUpdate(center));
   }
 
   void _stickDragStart(Offset globalPosition) {

--- a/lib/src/joystick.dart
+++ b/lib/src/joystick.dart
@@ -36,6 +36,7 @@ class Joystick extends StatefulWidget {
   /// Callback, which is called when the stick released.
   final Function? onStickDragEnd;
 
+  /// Decides if the stick's initial movement animation should be included. By default [true].
   final bool includeInitialAnimation;
 
   const Joystick({
@@ -50,7 +51,7 @@ class Joystick extends StatefulWidget {
     this.onStickDragStart,
     this.onStickDragEnd,
     this.includeInitialAnimation = true,
-  }) : super(key: key);
+  });
 
   @override
   State<Joystick> createState() => _JoystickState();

--- a/lib/src/joystick_arrow.dart
+++ b/lib/src/joystick_arrow.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_joystick/src/joystick.dart';
+import 'package:flutter_joystick/src/utils.dart';
+import 'dart:math' as math;
+
+class JoystickArrows extends StatefulWidget {
+  final Color arrowsColor;
+  final JoystickMode mode;
+  final double size;
+
+  const JoystickArrows({
+    super.key,
+    required this.arrowsColor,
+    required this.mode,
+    required this.size,
+  });
+
+  @override
+  State<JoystickArrows> createState() => _JoystickArrowsState();
+}
+
+class _JoystickArrowsState extends State<JoystickArrows>
+    with SingleTickerProviderStateMixin {
+  late Animation<double> animation;
+  late AnimationController controller;
+  final Tween<double> _rotationTween = Tween(begin: 0, end: 2);
+
+  @override
+  void initState() {
+    controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    );
+
+    animation = _rotationTween.animate(controller)
+      ..addListener(() {
+        setState(() {});
+      })
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          controller.repeat();
+        } else if (status == AnimationStatus.dismissed) {
+          controller.forward();
+        }
+      });
+
+    controller.forward();
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: CustomPaint(
+        painter: _ArrowPainter(
+          value: (controller.value * 100).toInt(),
+          color: widget.arrowsColor,
+          mode: widget.mode,
+        ),
+      ),
+    );
+  }
+}
+
+class _ArrowPainter extends CustomPainter {
+  final int value;
+  final Color color;
+  final JoystickMode mode;
+
+  _ArrowPainter({
+    required this.value,
+    required this.color,
+    required this.mode,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3;
+
+    // canvas.drawColor(
+    //   Colors.red,
+    //   BlendMode.src,
+    // );
+
+    drawVerticalArrows(canvas, paint, size);
+    drawHorizontalArrows(canvas, paint, size);
+  }
+
+  void drawVerticalArrows(
+    Canvas canvas,
+    Paint paint,
+    Size size,
+  ) {
+    if (mode != JoystickMode.horizontal) {
+      double xPosition = size.width / 2;
+      double top = -36;
+      double bottom = size.height - 36;
+      double rotationAngle = math.pi;
+      double moveX = size.width;
+
+      canvas.translate(moveX, 0);
+      canvas.rotate(rotationAngle);
+      _drawArrow(
+        canvas,
+        paint,
+        xPosition,
+        top,
+      );
+      canvas.translate(moveX, 0);
+      canvas.rotate(-rotationAngle);
+      _drawArrow(
+        canvas,
+        paint,
+        xPosition,
+        bottom,
+      );
+      canvas.translate(0, 0);
+    }
+  }
+
+  void drawHorizontalArrows(
+    Canvas canvas,
+    Paint paint,
+    Size size,
+  ) {
+    if (mode != JoystickMode.vertical) {
+      double yPosition = size.height / 2 - 36;
+      double left = 0;
+      double right = size.width;
+      double rotationAngle = math.pi / 2;
+      double moveXLeft = size.width / 2;
+      double moveXRight = size.width;
+      double moveY = size.height / 2;
+
+      canvas.translate(
+        moveXLeft,
+        moveY,
+      );
+      canvas.rotate(rotationAngle);
+      _drawArrow(
+        canvas,
+        paint,
+        left,
+        yPosition,
+      );
+      canvas.translate(
+        moveXRight,
+        0,
+      );
+      canvas.rotate(math.pi);
+      _drawArrow(
+        canvas,
+        paint..color,
+        right,
+        yPosition,
+      );
+    }
+  }
+
+  void _drawArrow(
+    Canvas canvas,
+    Paint paint,
+    double xPosition,
+    double yPosition,
+  ) {
+    var path = Path();
+    path.moveTo(xPosition - 5, yPosition - 12);
+    path.lineTo(xPosition, yPosition - 8);
+    path.lineTo(xPosition + 5, yPosition - 12);
+    canvas.drawPath(
+      path,
+      paint..color = evaluateColor(value < 33),
+    );
+
+    path = Path();
+    path.moveTo(xPosition - 7, yPosition - 5);
+    path.lineTo(xPosition, yPosition);
+    path.lineTo(xPosition + 7, yPosition - 5);
+    canvas.drawPath(
+      path,
+      paint..color = evaluateColor(value > 33 && value < 66),
+    );
+
+    path = Path();
+    path.moveTo(xPosition - 10, yPosition + 2);
+    path.lineTo(xPosition, yPosition + 9);
+    path.lineTo(xPosition + 10, yPosition + 2);
+    canvas.drawPath(path, paint..color = evaluateColor(value > 66));
+  }
+
+  evaluateColor(bool condition) {
+    Color resultColor = ColorUtils.darken(color, 0.14);
+    if (condition) {
+      resultColor = color;
+    }
+    return resultColor;
+  }
+
+  @override
+  bool shouldRepaint(_ArrowPainter oldDelegate) => oldDelegate.value != value;
+}

--- a/lib/src/joystick_arrow.dart
+++ b/lib/src/joystick_arrow.dart
@@ -89,11 +89,6 @@ class _ArrowPainter extends CustomPainter {
       ..style = PaintingStyle.stroke
       ..strokeWidth = 3;
 
-    // canvas.drawColor(
-    //   Colors.red,
-    //   BlendMode.src,
-    // );
-
     drawVerticalArrows(canvas, paint, size);
     drawHorizontalArrows(canvas, paint, size);
   }

--- a/lib/src/joystick_arrow.dart
+++ b/lib/src/joystick_arrow.dart
@@ -7,12 +7,14 @@ class JoystickArrows extends StatefulWidget {
   final Color arrowsColor;
   final JoystickMode mode;
   final double size;
+  final bool enableAnimation;
 
   const JoystickArrows({
     super.key,
     required this.arrowsColor,
     required this.mode,
     required this.size,
+    required this.enableAnimation,
   });
 
   @override
@@ -65,6 +67,7 @@ class _JoystickArrowsState extends State<JoystickArrows>
           value: (controller.value * 100).toInt(),
           color: widget.arrowsColor,
           mode: widget.mode,
+          enableAnimation: widget.enableAnimation,
         ),
       ),
     );
@@ -75,11 +78,13 @@ class _ArrowPainter extends CustomPainter {
   final int value;
   final Color color;
   final JoystickMode mode;
+  final bool enableAnimation;
 
   _ArrowPainter({
     required this.value,
     required this.color,
     required this.mode,
+    required this.enableAnimation,
   });
 
   @override
@@ -196,9 +201,9 @@ class _ArrowPainter extends CustomPainter {
   }
 
   evaluateColor(bool condition) {
-    Color resultColor = ColorUtils.darken(color, 0.14);
-    if (condition) {
-      resultColor = color;
+    Color resultColor = color;
+    if (!condition && enableAnimation) {
+      resultColor = ColorUtils.darken(color, 0.14);
     }
     return resultColor;
   }

--- a/lib/src/joystick_base.dart
+++ b/lib/src/joystick_base.dart
@@ -10,6 +10,7 @@ class JoystickBase extends StatelessWidget {
   final JoystickMode mode;
   final double size;
   final bool withBorderCircle;
+  final bool enableArrowAnimation;
 
   const JoystickBase({
     this.arrowsColor,
@@ -19,6 +20,7 @@ class JoystickBase extends StatelessWidget {
     this.mode = JoystickMode.all,
     this.size = 200,
     this.withBorderCircle = true,
+    this.enableArrowAnimation = true,
     Key? key,
   }) : super(key: key);
 
@@ -62,6 +64,7 @@ class JoystickBase extends StatelessWidget {
               arrowsColor: arrowsColor ?? color,
               mode: mode,
               size: size,
+              enableAnimation: enableArrowAnimation,
             ),
         ],
       ),

--- a/lib/src/joystick_base.dart
+++ b/lib/src/joystick_base.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-
+import 'package:flutter_joystick/src/joystick_arrow.dart';
 import 'joystick.dart';
 
 class JoystickBase extends StatelessWidget {
@@ -37,41 +37,45 @@ class JoystickBase extends StatelessWidget {
           )
         ],
       ),
-      child: CustomPaint(
-        painter: _JoystickBasePainter(
-          arrowsColor: arrowsColor ?? color,
-          color: color,
-          drawArrows: drawArrows,
-          mode: mode,
-          withBorderCircle: withBorderCircle,
-        ),
+      child: Stack(
+        children: [
+          SizedBox(
+            width: size,
+            height: size,
+            child: CustomPaint(
+              painter: _JoystickBasePainter(
+                color: color,
+                mode: mode,
+                withBorderCircle: withBorderCircle,
+              ),
+            ),
+          ),
+          if (drawArrows)
+            JoystickArrows(
+              arrowsColor: arrowsColor ?? color,
+              mode: mode,
+              size: size,
+            ),
+        ],
       ),
     );
   }
 }
 
 class _JoystickBasePainter extends CustomPainter {
-  final Color arrowsColor;
   final Color color;
-  final bool drawArrows;
   final JoystickMode mode;
   final bool withBorderCircle;
 
   _JoystickBasePainter({
-    required this.arrowsColor,
     required this.color,
-    required this.drawArrows,
     required this.mode,
     required this.withBorderCircle,
   });
 
   static const double borderStrokeWidthPercentage = 0.05;
-  static const double arrowStrokeWidthPercentage = 0.025;
   static const double innerCircleRadiusReductionPercentage = 0.06;
   static const double outermostCircleRadiusReductionPercentage = 0.3;
-  static const double arrowWidth = 0.15;
-  static const double arrowHeight = 0.1;
-  static const double arrowHeadOffset = 0.35;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -80,7 +84,6 @@ class _JoystickBasePainter extends CustomPainter {
     final center = Offset(radius, radius);
 
     drawCircles(canvas, center, diameter, withBorderCircle);
-    drawVerticalAndHorizontalArrows(canvas, center, diameter);
   }
 
   void drawCircles(
@@ -111,62 +114,6 @@ class _JoystickBasePainter extends CustomPainter {
       diameter / 2 - outermostCircleRadiusReductionPercentage * diameter,
       innerPaint,
     );
-  }
-
-  void drawVerticalAndHorizontalArrows(
-      Canvas canvas, Offset center, double diameter) {
-    final linePaint = Paint()
-      ..color = arrowsColor
-      ..strokeWidth = arrowStrokeWidthPercentage * diameter
-      ..style = PaintingStyle.stroke;
-    drawVerticalArrows(canvas, center, diameter, linePaint);
-    drawHorizontalArrows(canvas, center, diameter, linePaint);
-  }
-
-  void drawVerticalArrows(
-      Canvas canvas, Offset center, double diameter, Paint linePaint) {
-    if (drawArrows && mode != JoystickMode.horizontal) {
-      final height = arrowHeight * diameter;
-      final headOffset = arrowHeadOffset * diameter;
-      final width = arrowWidth * diameter;
-
-      final topArrowHeadOffset = center.dy - headOffset;
-      var topArrowHead = Offset(center.dx, topArrowHeadOffset);
-      canvas.drawLine(
-          topArrowHead, topArrowHead.translate(-width, height), linePaint);
-      canvas.drawLine(
-          topArrowHead, topArrowHead.translate(width, height), linePaint);
-
-      final bottomArrowHeadOffset = center.dy + headOffset;
-      var bottomArrowHead = Offset(center.dx, bottomArrowHeadOffset);
-      canvas.drawLine(bottomArrowHead,
-          bottomArrowHead.translate(-width, -height), linePaint);
-      canvas.drawLine(bottomArrowHead,
-          bottomArrowHead.translate(width, -height), linePaint);
-    }
-  }
-
-  void drawHorizontalArrows(
-      Canvas canvas, Offset center, double diameter, Paint linePaint) {
-    if (drawArrows && mode != JoystickMode.vertical) {
-      final height = arrowHeight * diameter;
-      final headOffset = arrowHeadOffset * diameter;
-      final width = arrowWidth * diameter;
-
-      final leftArrowHeadOffset = center.dx - headOffset;
-      final leftArrowHead = Offset(leftArrowHeadOffset, center.dy);
-      canvas.drawLine(
-          leftArrowHead, leftArrowHead.translate(height, -width), linePaint);
-      canvas.drawLine(
-          leftArrowHead, leftArrowHead.translate(height, width), linePaint);
-
-      final rightArrowHeadOffset = center.dx + headOffset;
-      var rightArrowHead = Offset(rightArrowHeadOffset, center.dy);
-      canvas.drawLine(
-          rightArrowHead, rightArrowHead.translate(-height, -width), linePaint);
-      canvas.drawLine(
-          rightArrowHead, rightArrowHead.translate(-height, width), linePaint);
-    }
   }
 
   @override

--- a/lib/src/joystick_base.dart
+++ b/lib/src/joystick_base.dart
@@ -25,9 +25,17 @@ class JoystickBase extends StatelessWidget {
     return Container(
       width: size,
       height: size,
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         color: Colors.transparent,
         shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: color.withOpacity(0.24),
+            spreadRadius: 1,
+            blurRadius: 16,
+            offset: const Offset(0, 4),
+          )
+        ],
       ),
       child: CustomPaint(
         painter: _JoystickBasePainter(
@@ -85,19 +93,23 @@ class _JoystickBasePainter extends CustomPainter {
       canvas.drawCircle(center, diameter / 2, borderPaint);
     }
 
-    final centerPaint = Paint()
+    final outerPaint = Paint()
+      ..color = color.withOpacity(0.84)
+      ..style = PaintingStyle.fill;
+
+    final innerPaint = Paint()
       ..color = color
       ..style = PaintingStyle.fill;
 
     canvas.drawCircle(
       center,
       diameter / 2 - innerCircleRadiusReductionPercentage * diameter,
-      centerPaint,
+      outerPaint,
     );
     canvas.drawCircle(
       center,
       diameter / 2 - outermostCircleRadiusReductionPercentage * diameter,
-      centerPaint,
+      innerPaint,
     );
   }
 

--- a/lib/src/joystick_base.dart
+++ b/lib/src/joystick_base.dart
@@ -4,6 +4,7 @@ import 'joystick.dart';
 
 class JoystickBase extends StatelessWidget {
   final Color? arrowsColor;
+  final List<BoxShadow>? boxShadows;
   final Color color;
   final bool drawArrows;
   final JoystickMode mode;
@@ -12,6 +13,7 @@ class JoystickBase extends StatelessWidget {
 
   const JoystickBase({
     this.arrowsColor,
+    this.boxShadows,
     this.color = const Color(0x50616161),
     this.drawArrows = true,
     this.mode = JoystickMode.all,
@@ -22,20 +24,25 @@ class JoystickBase extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Color boxShadowColor =
+        MediaQuery.of(context).platformBrightness == Brightness.dark
+            ? color.withOpacity(0.08)
+            : color.withOpacity(0.16);
     return Container(
       width: size,
       height: size,
       decoration: BoxDecoration(
         color: Colors.transparent,
         shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: color.withOpacity(0.16),
-            spreadRadius: 1,
-            blurRadius: 12,
-            offset: const Offset(0, 4),
-          )
-        ],
+        boxShadow: boxShadows ??
+            [
+              BoxShadow(
+                color: boxShadowColor,
+                spreadRadius: 1,
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+            ],
       ),
       child: Stack(
         children: [

--- a/lib/src/joystick_base.dart
+++ b/lib/src/joystick_base.dart
@@ -30,9 +30,9 @@ class JoystickBase extends StatelessWidget {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: color.withOpacity(0.24),
+            color: color.withOpacity(0.16),
             spreadRadius: 1,
-            blurRadius: 16,
+            blurRadius: 12,
             offset: const Offset(0, 4),
           )
         ],

--- a/lib/src/joystick_base.dart
+++ b/lib/src/joystick_base.dart
@@ -3,16 +3,20 @@ import 'package:flutter/material.dart';
 import 'joystick.dart';
 
 class JoystickBase extends StatelessWidget {
-  final JoystickMode mode;
-  final bool drawArrows;
-  final double size;
+  final Color? arrowsColor;
   final Color color;
+  final bool drawArrows;
+  final JoystickMode mode;
+  final double size;
+  final bool withBorderCircle;
 
   const JoystickBase({
-    this.mode = JoystickMode.all,
-    this.drawArrows = true,
-    this.size = 200,
+    this.arrowsColor,
     this.color = const Color(0x50616161),
+    this.drawArrows = true,
+    this.mode = JoystickMode.all,
+    this.size = 200,
+    this.withBorderCircle = true,
     Key? key,
   }) : super(key: key);
 
@@ -27,9 +31,11 @@ class JoystickBase extends StatelessWidget {
       ),
       child: CustomPaint(
         painter: _JoystickBasePainter(
-          mode: mode,
-          drawArrows: drawArrows,
+          arrowsColor: arrowsColor ?? color,
           color: color,
+          drawArrows: drawArrows,
+          mode: mode,
+          withBorderCircle: withBorderCircle,
         ),
       ),
     );
@@ -37,14 +43,18 @@ class JoystickBase extends StatelessWidget {
 }
 
 class _JoystickBasePainter extends CustomPainter {
-  final JoystickMode mode;
-  final bool drawArrows;
+  final Color arrowsColor;
   final Color color;
+  final bool drawArrows;
+  final JoystickMode mode;
+  final bool withBorderCircle;
 
   _JoystickBasePainter({
-    required this.mode,
-    required this.drawArrows,
+    required this.arrowsColor,
     required this.color,
+    required this.drawArrows,
+    required this.mode,
+    required this.withBorderCircle,
   });
 
   static const double borderStrokeWidthPercentage = 0.05;
@@ -61,35 +71,40 @@ class _JoystickBasePainter extends CustomPainter {
     final radius = diameter / 2;
     final center = Offset(radius, radius);
 
-    drawCircles(canvas, center, diameter);
+    drawCircles(canvas, center, diameter, withBorderCircle);
     drawVerticalAndHorizontalArrows(canvas, center, diameter);
   }
 
-  void drawCircles(Canvas canvas, Offset center, double diameter) {
-    final borderPaint = Paint()
-      ..color = color
-      ..strokeWidth = borderStrokeWidthPercentage * diameter
-      ..style = PaintingStyle.stroke;
+  void drawCircles(
+      Canvas canvas, Offset center, double diameter, bool withBorderCircle) {
+    if (withBorderCircle) {
+      final borderPaint = Paint()
+        ..color = color
+        ..strokeWidth = borderStrokeWidthPercentage * diameter
+        ..style = PaintingStyle.stroke;
+      canvas.drawCircle(center, diameter / 2, borderPaint);
+    }
 
     final centerPaint = Paint()
       ..color = color
       ..style = PaintingStyle.fill;
 
-    canvas.drawCircle(center, diameter / 2, borderPaint);
     canvas.drawCircle(
-        center,
-        diameter / 2 - innerCircleRadiusReductionPercentage * diameter,
-        centerPaint);
+      center,
+      diameter / 2 - innerCircleRadiusReductionPercentage * diameter,
+      centerPaint,
+    );
     canvas.drawCircle(
-        center,
-        diameter / 2 - outermostCircleRadiusReductionPercentage * diameter,
-        centerPaint);
+      center,
+      diameter / 2 - outermostCircleRadiusReductionPercentage * diameter,
+      centerPaint,
+    );
   }
 
   void drawVerticalAndHorizontalArrows(
       Canvas canvas, Offset center, double diameter) {
     final linePaint = Paint()
-      ..color = color
+      ..color = arrowsColor
       ..strokeWidth = arrowStrokeWidthPercentage * diameter
       ..style = PaintingStyle.stroke;
     drawVerticalArrows(canvas, center, diameter, linePaint);

--- a/lib/src/joystick_base.dart
+++ b/lib/src/joystick_base.dart
@@ -21,8 +21,8 @@ class JoystickBase extends StatelessWidget {
     this.size = 200,
     this.withBorderCircle = true,
     this.enableArrowAnimation = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/joystick_stick.dart
+++ b/lib/src/joystick_stick.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
 class JoystickStick extends StatelessWidget {
-  final MaterialColor color;
-  final Color shadowColor;
+  final Color color;
+  final Color? shadowColor;
   final double size;
 
   const JoystickStick({
     this.color = Colors.lightBlue,
-    this.shadowColor = Colors.blue,
+    this.shadowColor,
     this.size = 50,
     Key? key,
   }) : super(key: key);
@@ -21,7 +21,7 @@ class JoystickStick extends StatelessWidget {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: shadowColor.withOpacity(0.5),
+            color: shadowColor ?? color.withOpacity(0.5),
             spreadRadius: 5,
             blurRadius: 7,
             offset: const Offset(0, 3),
@@ -31,11 +31,30 @@ class JoystickStick extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            color.shade900,
-            color.shade400,
+            darken(color, 0.9),
+            lighten(color, 0.3),
           ],
         ),
       ),
     );
+  }
+
+  Color darken(Color color, [double amount = .1]) {
+    assert(amount >= 0 && amount <= 1);
+
+    final hsl = HSLColor.fromColor(color);
+    final hslDark = hsl.withLightness((hsl.lightness - amount).clamp(0.0, 1.0));
+
+    return hslDark.toColor();
+  }
+
+  Color lighten(Color color, [double amount = .1]) {
+    assert(amount >= 0 && amount <= 1);
+
+    final hsl = HSLColor.fromColor(color);
+    final hslLight =
+        hsl.withLightness((hsl.lightness + amount).clamp(0.0, 1.0));
+
+    return hslLight.toColor();
   }
 }

--- a/lib/src/joystick_stick.dart
+++ b/lib/src/joystick_stick.dart
@@ -31,8 +31,8 @@ class JoystickStick extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            darken(color, 0.9),
-            lighten(color, 0.3),
+            darken(color),
+            lighten(color),
           ],
         ),
       ),

--- a/lib/src/joystick_stick.dart
+++ b/lib/src/joystick_stick.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 
 class JoystickStick extends StatelessWidget {
+  final MaterialColor color;
+  final Color shadowColor;
   final double size;
 
   const JoystickStick({
+    this.color = Colors.lightBlue,
+    this.shadowColor = Colors.blue,
     this.size = 50,
     Key? key,
   }) : super(key: key);
@@ -17,7 +21,7 @@ class JoystickStick extends StatelessWidget {
         shape: BoxShape.circle,
         boxShadow: [
           BoxShadow(
-            color: Colors.blue.withOpacity(0.5),
+            color: shadowColor.withOpacity(0.5),
             spreadRadius: 5,
             blurRadius: 7,
             offset: const Offset(0, 3),
@@ -27,8 +31,8 @@ class JoystickStick extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            Colors.lightBlue.shade900,
-            Colors.lightBlue.shade400,
+            color.shade900,
+            color.shade400,
           ],
         ),
       ),

--- a/lib/src/joystick_stick.dart
+++ b/lib/src/joystick_stick.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_joystick/src/utils.dart';
 
 class JoystickStick extends StatelessWidget {
   final Color color;
@@ -31,30 +32,11 @@ class JoystickStick extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            darken(color),
-            lighten(color),
+            ColorUtils.darken(color),
+            ColorUtils.lighten(color),
           ],
         ),
       ),
     );
-  }
-
-  Color darken(Color color, [double amount = .1]) {
-    assert(amount >= 0 && amount <= 1);
-
-    final hsl = HSLColor.fromColor(color);
-    final hslDark = hsl.withLightness((hsl.lightness - amount).clamp(0.0, 1.0));
-
-    return hslDark.toColor();
-  }
-
-  Color lighten(Color color, [double amount = .1]) {
-    assert(amount >= 0 && amount <= 1);
-
-    final hsl = HSLColor.fromColor(color);
-    final hslLight =
-        hsl.withLightness((hsl.lightness + amount).clamp(0.0, 1.0));
-
-    return hslLight.toColor();
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class ColorUtils {
+  static Color darken(Color color, [double amount = .1]) {
+    assert(amount >= 0 && amount <= 1);
+
+    final hsl = HSLColor.fromColor(color);
+    final hslDark = hsl.withLightness((hsl.lightness - amount).clamp(0.0, 1.0));
+
+    return hslDark.toColor();
+  }
+
+  static Color lighten(Color color, [double amount = .1]) {
+    assert(amount >= 0 && amount <= 1);
+
+    final hsl = HSLColor.fromColor(color);
+    final hslLight =
+        hsl.withLightness((hsl.lightness + amount).clamp(0.0, 1.0));
+
+    return hslLight.toColor();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -67,6 +67,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -79,34 +103,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -124,18 +148,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -156,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -168,13 +192,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.1.3 <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
   - https://paypal.com/donate/?hosted_button_id=EG9DHRCSB5MY4
 
 environment:
-  sdk: ">=3.1.3 <4.0.0"
+  sdk: '>=3.1.3 <4.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_joystick
 description: A virtual joystick widget for Flutter applications. Highly flexible and customizable.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/pavelzaichyk/flutter_joystick
 repository: https://github.com/pavelzaichyk/flutter_joystick
 funding:
@@ -9,7 +9,7 @@ funding:
   - https://paypal.com/donate/?hosted_button_id=EG9DHRCSB5MY4
 
 environment:
-  sdk: '>=3.1.3 <4.0.0'
+  sdk: ">=3.1.3 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Exposed **JoystickStick** widget's *color* and *shadowColor* to allow users have fine grained control.
  
Exposed **JoystickBase** widget's  
  - *arrowsColor* to let user decide the colors for the arrows and
  - *withBorderCircle* to allow users decide if they need the circular border around their joystick.
  
These changes allow **fine grained control** for the user and allow them to customize the joystick to **match their theme**.

**Examples:**
![Screenshot from 2024-05-30 13-40-41](https://github.com/pavelzaichyk/flutter_joystick/assets/99329337/7d833f4e-8640-4b79-8f2a-b5a9460a7a11)
![Screenshot from 2024-05-30 13-38-02](https://github.com/pavelzaichyk/flutter_joystick/assets/99329337/6c4535f4-f9fe-45bd-83f8-e9bd383fe8a8)
![Screenshot from 2024-05-30 13-41-54](https://github.com/pavelzaichyk/flutter_joystick/assets/99329337/0fe12a93-8f7d-4786-962b-33c82916cd48)