### PR TITLE
Fix duplicated callbacks

### DIFF
--- a/lib/src/joystick.dart
+++ b/lib/src/joystick.dart
@@ -186,6 +186,7 @@ class _JoystickState extends State<Joystick> {
   }
 
   void _runCallback() {
+    _callbackTimer?.cancel();
     _callbackTimer = Timer.periodic(widget.period, (timer) {
       widget.listener(StickDragDetails(_stickOffset.dx, _stickOffset.dy));
     });


### PR DESCRIPTION
Closes #10 by always canceling the existing timer before starting a new one.